### PR TITLE
feat: add support for granting USAGE privileges on Snowflake file formats to specific roles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,9 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-## [1.1.0](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-file-format/compare/v1.0.0...v1.1.0) (2026-02-17)
-
-### Features
-
-* convert to single-module repository layout ([968ff86](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-file-format/commit/968ff86fc5deb94ce8b4484d4304913a048aa392))
-
 ## [unreleased]
+
+### 🚀 Features
+
+- Add Snowflake file format module with grants support
+## [1.1.0] - 2026-02-17
 
 ### 🚀 Features
 
@@ -20,6 +15,11 @@ All notable changes to this project will be documented in this file.
 - Add standardized header comments to Terraform configuration files
 - *(main.tf)* Add standardized header comments to main configuration file
 - Update CHANGELOG.md [skip ci]
+- Update CHANGELOG.md [skip ci]
+
+### ⚙️ Miscellaneous Tasks
+
+- *(release)* Version 1.1.0 [skip ci]
 ## [1.0.0] - 2026-02-07
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ module "file_formats" {
       trim_space      = true
       null_if         = ["NULL", "null", ""]
       comment         = "Standard CSV format with header and null handling"
+      usage_roles     = ["DATA_ENGINEER", "DATA_ANALYST"]
     }
     "json_standard" = {
       database          = "MY_DATABASE"
@@ -60,6 +61,7 @@ module "file_formats" {
       strip_outer_array = true
       strip_null_values = true
       comment           = "Standard JSON format for API data ingestion"
+      usage_roles       = ["DATA_ENGINEER"]
     }
     "parquet_standard" = {
       database       = "MY_DATABASE"
@@ -142,6 +144,7 @@ provider "snowflake" {
 | disable_snowflake_data | bool | false | Disable Snowflake data (XML) |
 | disable_auto_convert | bool | false | Disable auto convert (XML) |
 | comment | string | null | Description of the file format |
+| usage_roles | list(string) | [] | List of roles to grant USAGE privilege |
 
 ### Valid Format Types
 

--- a/examples/multiple-file-formats/README.md
+++ b/examples/multiple-file-formats/README.md
@@ -19,6 +19,7 @@ module "file_formats" {
       trim_space      = true
       null_if         = ["NULL", "null", ""]
       comment         = "Standard CSV format with header and null handling"
+      usage_roles     = ["DATA_ENGINEER", "DATA_ANALYST"]
     }
     "json_standard" = {
       database          = "MY_DATABASE"
@@ -28,6 +29,7 @@ module "file_formats" {
       strip_outer_array = true
       strip_null_values = true
       comment           = "Standard JSON format for API data ingestion"
+      usage_roles       = ["DATA_ENGINEER"]
     }
     "parquet_standard" = {
       database       = "MY_DATABASE"

--- a/examples/multiple-file-formats/variables.tf
+++ b/examples/multiple-file-formats/variables.tf
@@ -40,6 +40,9 @@ variable "file_format_configs" {
     disable_auto_convert   = optional(bool, false)
 
     comment = optional(string, null)
+
+    # Grants
+    usage_roles = optional(list(string), [])
   }))
   default = {
     "csv_standard" = {
@@ -52,6 +55,7 @@ variable "file_format_configs" {
       trim_space      = true
       null_if         = ["NULL", "null", ""]
       comment         = "Standard CSV format with header and null handling"
+      usage_roles     = []
     }
     "csv_pipe_delimited" = {
       database        = "MY_DATABASE"
@@ -62,6 +66,7 @@ variable "file_format_configs" {
       skip_header     = 0
       compression     = "GZIP"
       comment         = "Pipe-delimited CSV format for legacy systems"
+      usage_roles     = []
     }
     "json_standard" = {
       database          = "MY_DATABASE"
@@ -72,6 +77,7 @@ variable "file_format_configs" {
       strip_null_values = true
       compression       = "AUTO"
       comment           = "Standard JSON format for API data ingestion"
+      usage_roles       = []
     }
     "parquet_standard" = {
       database       = "MY_DATABASE"
@@ -81,6 +87,7 @@ variable "file_format_configs" {
       binary_as_text = false
       compression    = "AUTO"
       comment        = "Parquet format for analytics workloads"
+      usage_roles    = []
     }
   }
 }

--- a/examples/single-file-format/README.md
+++ b/examples/single-file-format/README.md
@@ -17,6 +17,7 @@ module "file_format" {
       field_delimiter = ","
       skip_header     = 1
       comment         = "Standard CSV file format with header row"
+      usage_roles     = ["DATA_ENGINEER"]
     }
   }
 }

--- a/examples/single-file-format/variables.tf
+++ b/examples/single-file-format/variables.tf
@@ -40,6 +40,9 @@ variable "file_format_configs" {
     disable_auto_convert   = optional(bool, false)
 
     comment = optional(string, null)
+
+    # Grants
+    usage_roles = optional(list(string), [])
   }))
   default = {
     "csv_format" = {
@@ -50,6 +53,7 @@ variable "file_format_configs" {
       field_delimiter = ","
       skip_header     = 1
       comment         = "Standard CSV file format with header row"
+      usage_roles     = []
     }
   }
 }

--- a/test/multiple_file_formats_test.go
+++ b/test/multiple_file_formats_test.go
@@ -38,6 +38,7 @@ func TestMultipleFileFormats(t *testing.T) {
 			"skip_header":     1,
 			"trim_space":      true,
 			"comment":         "Terratest CSV file format",
+			"usage_roles":     []string{},
 		},
 		"json_format": map[string]interface{}{
 			"database":          databaseName,
@@ -47,6 +48,7 @@ func TestMultipleFileFormats(t *testing.T) {
 			"strip_outer_array": true,
 			"strip_null_values": true,
 			"comment":           "Terratest JSON file format",
+			"usage_roles":       []string{},
 		},
 		"parquet_format": map[string]interface{}{
 			"database":       databaseName,
@@ -55,6 +57,7 @@ func TestMultipleFileFormats(t *testing.T) {
 			"format_type":    "PARQUET",
 			"binary_as_text": false,
 			"comment":        "Terratest Parquet file format",
+			"usage_roles":    []string{},
 		},
 	}
 

--- a/test/single_file_format_test.go
+++ b/test/single_file_format_test.go
@@ -35,6 +35,7 @@ func TestSingleFileFormat(t *testing.T) {
 			"skip_header":     1,
 			"trim_space":      true,
 			"comment":         "Terratest single file format test",
+			"usage_roles":     []string{},
 		},
 	}
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,9 @@ variable "file_format_configs" {
     disable_auto_convert   = optional(bool, false)
 
     comment = optional(string, null)
+
+    # Grants
+    usage_roles = optional(list(string), [])
   }))
   default = {}
 


### PR DESCRIPTION
This pull request adds support for granting USAGE privileges on Snowflake file formats to specific roles, allowing for more granular access control. The changes introduce a new `usage_roles` attribute to file format configurations, update documentation and examples to reflect this feature, and implement the necessary Terraform logic to manage these grants.

**Grants support for file formats:**

* Added a `usage_roles` attribute (list of roles) to the file format configuration schema in `variables.tf`, `examples/single-file-format/variables.tf`, and `examples/multiple-file-formats/variables.tf` to specify which roles should receive USAGE privileges. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR49-R51) [[2]](diffhunk://#diff-28c39d6c6a775fa64ac34c5dd8ef01b9d535945e43af7033acf92c85e9aeb0b3R43-R45) [[3]](diffhunk://#diff-cc8d18e707ae3f9688eda55e82a6fde8aa5edddf8e637d5fb3efc3838361eed0R43-R45)
* Updated all relevant examples and documentation (`README.md`, `examples/*/README.md`) to demonstrate how to use the new `usage_roles` field in file format definitions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147) [[4]](diffhunk://#diff-e14d67cb6c13f098fc88738e891385c31ff975d5423982e0eeee4022edaa6152R22) [[5]](diffhunk://#diff-e14d67cb6c13f098fc88738e891385c31ff975d5423982e0eeee4022edaa6152R32) [[6]](diffhunk://#diff-19c97944d9c8f28f546e758cd8b8a13a2907cd08fa230ad257904f57a081b55fR20)

**Terraform logic for grants:**

* Implemented a new local (`local.file_format_usage_grants`) and a `snowflake_grant_privileges_to_account_role` resource in `main.tf` to grant USAGE on each file format to the specified roles.

**Testing and validation:**

* Updated Terratest test cases to include the new `usage_roles` attribute in test payloads for both single and multiple file format scenarios. [[1]](diffhunk://#diff-30d715e5d6e3e9b10b6d8182342b651083edca7aac6940aa1144b0bc7fd1f0b1R41) [[2]](diffhunk://#diff-30d715e5d6e3e9b10b6d8182342b651083edca7aac6940aa1144b0bc7fd1f0b1R51) [[3]](diffhunk://#diff-30d715e5d6e3e9b10b6d8182342b651083edca7aac6940aa1144b0bc7fd1f0b1R60) [[4]](diffhunk://#diff-4bad2d9269c72291aed111b42fea16fd68e6e13d3c5f286cc0b6e9492ec5d68dR38)

**Documentation and changelog:**

* Updated `CHANGELOG.md` to document the addition of file format grants support and other miscellaneous release tasks. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R6) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18-R22)

These changes make it easier to manage file format privileges in Snowflake directly from Terraform, improving security and maintainability.